### PR TITLE
feat: スマートフォン・タブレット用タッチ操作を追加

### DIFF
--- a/main.go
+++ b/main.go
@@ -211,7 +211,7 @@ func (g *Game) resetGame() {
 func (g *Game) Update() error {
 	switch g.State {
 	case StatePlaying:
-		// Handle input
+		// Handle keyboard input
 		// F key for blue unit jump
 		if inpututil.IsKeyJustPressed(ebiten.KeyF) {
 			g.BlueUnit.jump()
@@ -220,6 +220,19 @@ func (g *Game) Update() error {
 		// J key for red unit jump
 		if inpututil.IsKeyJustPressed(ebiten.KeyJ) {
 			g.RedUnit.jump()
+		}
+
+		// Handle touch input for gameplay
+		touchIDs := inpututil.AppendJustPressedTouchIDs(nil)
+		for _, id := range touchIDs {
+			x, _ := ebiten.TouchPosition(id)
+			// Left half of screen = F key (blue unit jump)
+			if x < ScreenWidth/2 {
+				g.BlueUnit.jump()
+			} else {
+				// Right half of screen = J key (red unit jump)
+				g.RedUnit.jump()
+			}
 		}
 
 		// Update physics for both units
@@ -236,6 +249,12 @@ func (g *Game) Update() error {
 	case StateGameOver, StateCleared:
 		// Handle restart with space key
 		if inpututil.IsKeyJustPressed(ebiten.KeySpace) {
+			g.resetGame()
+		}
+
+		// Handle touch input for retry - any touch triggers retry
+		touchIDs := inpututil.AppendJustPressedTouchIDs(nil)
+		if len(touchIDs) > 0 {
 			g.resetGame()
 		}
 	}

--- a/web/index.html
+++ b/web/index.html
@@ -69,9 +69,14 @@
         
         <div class="control-section">
             <h3>🎮 Controls</h3>
-            <p><strong>F key:</strong> Blue character jump</p>
-            <p><strong>J key:</strong> Red character jump</p>
-            <p><strong>SPACE:</strong> Restart when game over/cleared</p>
+            <p><strong>Desktop:</strong></p>
+            <p>• <strong>F key:</strong> Blue character jump</p>
+            <p>• <strong>J key:</strong> Red character jump</p>
+            <p>• <strong>SPACE:</strong> Restart when game over/cleared</p>
+            <p><strong>Mobile/Tablet:</strong></p>
+            <p>• <strong>Tap left half:</strong> Blue character jump</p>
+            <p>• <strong>Tap right half:</strong> Red character jump</p>
+            <p>• <strong>Tap anywhere:</strong> Restart when game over/cleared</p>
         </div>
         
         <div class="control-section">


### PR DESCRIPTION
## Summary
- 画面左半分タップでFキー相当（青キャラジャンプ）
- 画面右半分タップでJキー相当（赤キャラジャンプ）
- リトライ画面では任意の場所をタップでリトライ
- HTMLにモバイル操作説明を追加

Fixes #2

Generated with [Claude Code](https://claude.ai/code)