### PR TITLE
feat: add Gemini Code Assist Japanese configuration

### DIFF
--- a/.gemini/config.json
+++ b/.gemini/config.json
@@ -1,0 +1,38 @@
+{
+  "codeAssist": {
+    "language": "japanese",
+    "locale": "ja-JP",
+    "enabled": true,
+    "features": {
+      "codeReview": {
+        "enabled": true,
+        "language": "ja",
+        "outputStyle": "japanese"
+      },
+      "suggestions": {
+        "enabled": true,
+        "language": "ja"
+      },
+      "explanations": {
+        "enabled": true,
+        "language": "ja"
+      },
+      "autoComplete": {
+        "enabled": true,
+        "commentLanguage": "ja"
+      }
+    },
+    "culturalSettings": {
+      "country": "JP",
+      "timezone": "Asia/Tokyo",
+      "dateFormat": "YYYY/MM/DD",
+      "context": "japan"
+    },
+    "reviewPreferences": {
+      "outputLanguage": "japanese",
+      "detailLevel": "detailed",
+      "includeExplanations": true,
+      "culturallyAppropriate": true
+    }
+  }
+}

--- a/.github/gemini-config.yml
+++ b/.github/gemini-config.yml
@@ -1,0 +1,33 @@
+gemini:
+  codeAssist:
+    language: ja
+    reviewLanguage: japanese
+    prReviewLanguage: japanese
+    issueLanguage: japanese
+  triggers:
+    - "@gemini"
+    - "@gemini-ja"
+    - "@ジェミニ"
+  settings:
+    culturalContext: japan
+    outputLanguage: ja
+    locale: ja-JP
+    timezone: Asia/Tokyo
+  features:
+    pullRequestReview:
+      enabled: true
+      language: ja
+      autoReview: false
+      detailedFeedback: true
+    issueAnalysis:
+      enabled: true
+      language: ja
+    codeExplanation:
+      enabled: true
+      language: ja
+      includeContext: true
+  preferences:
+    commentStyle: polite
+    explanationDepth: detailed
+    includeExamples: true
+    culturallyAppropriate: true

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,21 @@
+{
+  "aiCodeAssist.language": "ja",
+  "aiCodeAssist.locale": "ja-JP",
+  "aiCodeAssist.reviewLanguage": "japanese",
+  "aiCodeAssist.commentLanguage": "ja",
+  "gemini.codeAssist.defaultLanguage": "japanese",
+  "gemini.codeAssist.reviewSettings": {
+    "language": "ja",
+    "locale": "ja-JP",
+    "culturalContext": "japan"
+  },
+  "gemini.codeAssist.enabled": true,
+  "gemini.codeAssist.language": "japanese",
+  "gemini.codeAssist.autoReview": true,
+  "gemini.codeAssist.reviewOnSave": true,
+  "gemini.codeAssist.culturalSettings": {
+    "country": "JP",
+    "language": "ja",
+    "timezone": "Asia/Tokyo"
+  }
+}

--- a/ai-config.json
+++ b/ai-config.json
@@ -1,0 +1,23 @@
+{
+  "gemini": {
+    "codeAssist": {
+      "language": "japanese",
+      "locale": "ja-JP",
+      "reviewSettings": {
+        "outputLanguage": "ja",
+        "commentStyle": "japanese", 
+        "cultureAware": true
+      },
+      "preferences": {
+        "reviewLanguage": "japanese",
+        "suggestionLanguage": "japanese",
+        "explanationLanguage": "japanese"
+      }
+    }
+  },
+  "ai": {
+    "defaultLanguage": "ja",
+    "reviewLanguage": "japanese",
+    "locale": "ja-JP"
+  }
+}


### PR DESCRIPTION
Gemini Code Assistの日本語設定を追加

## 変更内容
- VS Code設定で日本語AIコードアシスタンスを設定
- 日本語レビュー用のプロジェクト全体AI設定を追加
- 文化的設定を含むGemini固有設定を追加
- 日本語PRレビュー用GitHub統合設定を追加

Resolves #3

🤖 Generated with [Claude Code](https://claude.ai/code)