### PR TITLE
feat: Gemini Code Assistの日本語設定を追加

### DIFF
--- a/.gemini/config.json
+++ b/.gemini/config.json
@@ -1,0 +1,70 @@
+{
+  "version": "1.0",
+  "gemini": {
+    "model": "gemini-1.5-pro",
+    "language": "ja",
+    "locale": "ja-JP",
+    "region": "asia-northeast1"
+  },
+  "code_assist": {
+    "enabled": true,
+    "auto_complete": true,
+    "auto_review": true,
+    "language_preference": "japanese",
+    "communication_style": {
+      "politeness_level": "high",
+      "formality": "business",
+      "tone": "helpful_and_constructive"
+    }
+  },
+  "review_settings": {
+    "default_language": "ja",
+    "review_depth": "detailed",
+    "include_suggestions": true,
+    "include_explanations": true,
+    "focus_areas": [
+      "コードの品質",
+      "パフォーマンス",
+      "セキュリティ",
+      "可読性",
+      "保守性",
+      "Go言語の慣例",
+      "WebAssembly最適化"
+    ],
+    "cultural_adaptations": {
+      "use_honorifics": true,
+      "polite_suggestions": true,
+      "encourage_learning": true
+    }
+  },
+  "pr_integration": {
+    "enabled": true,
+    "auto_trigger": true,
+    "triggers": [
+      "@gemini",
+      "@gemini-ja",
+      "@ジェミニ",
+      "@コードレビュー",
+      "@レビューお願いします"
+    ],
+    "review_template": {
+      "header": "## 📝 コードレビュー結果\n\nGemini Code Assistによるレビューを実施いたします。",
+      "footer": "\n---\n*このレビューはGemini Code Assistにより自動生成されました。*",
+      "sections": [
+        "概要",
+        "良い点",
+        "改善提案",
+        "セキュリティチェック",
+        "パフォーマンス",
+        "その他の気づき"
+      ]
+    }
+  },
+  "japanese_specific": {
+    "use_keigo": true,
+    "business_tone": true,
+    "clear_explanations": true,
+    "helpful_suggestions": true,
+    "encourage_best_practices": true
+  }
+}

--- a/.github/gemini-config.yml
+++ b/.github/gemini-config.yml
@@ -1,0 +1,54 @@
+gemini:
+  language: "ja"
+  locale: "ja-JP"
+  
+  # プルリクエストレビュー設定
+  pr_review:
+    enabled: true
+    language: "japanese"
+    style: "polite"
+    tone: "constructive"
+    format: "structured"
+    
+    # 日本語レビューテンプレート
+    templates:
+      review_intro: "コードレビューを実施いたします。"
+      review_conclusion: "レビューは以上です。ご確認ください。"
+      approval: "承認いたします。"
+      request_changes: "修正をお願いいたします。"
+    
+    # レビューフォーカスエリア
+    focus_areas:
+      - "コードの可読性"
+      - "パフォーマンス"
+      - "セキュリティ"
+      - "ベストプラクティス"
+      - "バグの可能性"
+      - "テストカバレッジ"
+    
+    # 文化的コンテキスト
+    cultural_context:
+      country: "japan"
+      communication_style: "polite"
+      feedback_approach: "constructive"
+      
+  # トリガー設定
+  triggers:
+    - "@gemini"
+    - "@gemini-ja"
+    - "@ジェミニ"
+    - "@レビュー"
+    
+  # AI設定
+  ai_settings:
+    model: "gemini-pro"
+    temperature: 0.3
+    max_tokens: 2048
+    include_context: true
+    
+  # 除外設定
+  exclude_files:
+    - "*.md"
+    - "*.txt"
+    - "node_modules/**/*"
+    - ".git/**/*"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,21 @@
+{
+  "gemini-code-assist.language": "ja",
+  "gemini-code-assist.locale": "ja-JP",
+  "gemini-code-assist.reviewLanguage": "japanese",
+  "gemini-code-assist.culturalContext": "japan",
+  "gemini-code-assist.enableAutoReview": true,
+  "gemini-code-assist.reviewLevel": "detailed",
+  "gemini-code-assist.includeContext": true,
+  "gemini-code-assist.autoSuggest": true,
+  "gemini-code-assist.outputLanguage": "ja",
+  "gemini-code-assist.prompt": {
+    "reviewStyle": "polite",
+    "tone": "constructive",
+    "format": "structured"
+  },
+  "gemini-code-assist.triggers": [
+    "@gemini",
+    "@gemini-ja", 
+    "@ジェミニ"
+  ]
+}

--- a/ai-config.json
+++ b/ai-config.json
@@ -1,0 +1,42 @@
+{
+  "project": {
+    "name": "egj2025",
+    "language": "go",
+    "framework": "wasm"
+  },
+  "ai": {
+    "provider": "gemini",
+    "language": "japanese",
+    "locale": "ja-JP",
+    "cultural_context": "japan"
+  },
+  "code_review": {
+    "enabled": true,
+    "language": "ja",
+    "style": {
+      "politeness": "high",
+      "formality": "moderate",
+      "tone": "constructive"
+    },
+    "focus": [
+      "可読性の向上",
+      "パフォーマンスの最適化", 
+      "セキュリティの確認",
+      "Go言語のベストプラクティス",
+      "WebAssembly最適化",
+      "エラーハンドリング"
+    ]
+  },
+  "suggestions": {
+    "language": "ja",
+    "include_explanations": true,
+    "provide_examples": true,
+    "reference_docs": true
+  },
+  "communication": {
+    "greeting": "コードレビューを開始します。",
+    "closing": "レビューは以上です。",
+    "encouragement": true,
+    "constructive_feedback": true
+  }
+}


### PR DESCRIPTION
Gemini Code Assistの日本語設定を追加

Zenn記事を参考にGemini Code Assistが日本語でコードレビューを行うための設定を実装

## 変更内容
- VS Code設定で日本語AIコードアシスタンスを設定
- 日本語レビュー用のプロジェクト全体AI設定を追加
- 文化的設定を含むGemini固有設定を追加
- 日本語PRレビュー用GitHub統合設定を追加

Resolves #3

Generated with [Claude Code](https://claude.ai/code)