### PR TITLE
feat: ASCIIアートからステージを生成するツールを追加

### DIFF
--- a/cmd/stagegen/README.md
+++ b/cmd/stagegen/README.md
@@ -37,6 +37,7 @@ OOOOOOOOOO
 - `stageN.go` ファイルが生成されます
 - `LoadStageN()` 関数とキャラクター開始位置を返す `GetStageNStartPositions()` 関数が含まれます
 - グリッド座標系（40x30セル、20px/セル）を使用します
+- 生成されるコードには常に `CreateGridGroundPlatform()` が含まれ、ASCIIアートで定義したプラットフォームが追加されます
 
 ## 生成されるコードの例
 

--- a/cmd/stagegen/README.md
+++ b/cmd/stagegen/README.md
@@ -1,0 +1,62 @@
+# ステージ生成ツール (Stage Generator)
+
+ASCII artからEbitengineゲーム用のステージファイルを生成するツールです。
+
+## 使用方法
+
+```bash
+go run cmd/stagegen/main.go <input.txt>
+```
+
+例:
+```bash
+go run cmd/stagegen/main.go stage1.txt
+```
+
+## ASCII art記号
+
+- `.` = 空間（穴）
+- `O` = 足場、壁
+- `G` = ゴール
+- `L` = 青キャラの初期位置（右向きに歩く）
+- `R` = 赤キャラの初期位置（左向きに歩く）
+
+## 入力例
+
+```
+OOOOOOOOOO
+O........O
+O........O
+O........O
+OL..GG..RO
+OOOOOOOOOO
+```
+
+## 出力
+
+- `stageN.go` ファイルが生成されます
+- `LoadStageN()` 関数とキャラクター開始位置を返す `GetStageNStartPositions()` 関数が含まれます
+- グリッド座標系（40x30セル、20px/セル）を使用します
+
+## 生成されるコードの例
+
+```go
+package main
+
+// LoadStage1 creates stage 1 - Generated from ASCII art
+func LoadStage1() *Stage {
+    return &Stage{
+        Platforms: []Platform{
+            CreateGridGroundPlatform(),
+            CreateGridPlatform(0, 0, 10, 1),
+            // ... その他のプラットフォーム
+            CreateGridGoalPlatform(4, 4, 2, 1),
+        },
+    }
+}
+
+// GetStage1StartPositions returns the starting positions for stage 1
+func GetStage1StartPositions() (blueX, blueY, redX, redY float64) {
+    return 20, 80, 160, 80
+}
+```

--- a/cmd/stagegen/main.go
+++ b/cmd/stagegen/main.go
@@ -1,0 +1,257 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"log"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"text/template"
+)
+
+// StageData represents the parsed stage data from ASCII art
+type StageData struct {
+	StageNumber     int
+	Platforms       []PlatformData
+	GoalPlatforms   []PlatformData
+	BlueStartX      int
+	BlueStartY      int
+	RedStartX       int
+	RedStartY       int
+	BlueStartPixelX int
+	BlueStartPixelY int
+	RedStartPixelX  int
+	RedStartPixelY  int
+}
+
+// PlatformData represents a platform in grid coordinates
+type PlatformData struct {
+	X      int
+	Y      int
+	Width  int
+	Height int
+}
+
+// parseASCIIArt parses ASCII art file and returns stage data
+func parseASCIIArt(filename string) (*StageData, error) {
+	file, err := os.Open(filename)
+	if err != nil {
+		return nil, fmt.Errorf("ファイルを開けませんでした: %v", err)
+	}
+	defer file.Close()
+
+	var lines []string
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text())
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("ファイル読み込みエラー: %v", err)
+	}
+
+	if len(lines) == 0 {
+		return nil, fmt.Errorf("空のファイルです")
+	}
+
+	// Extract stage number from filename
+	baseName := filepath.Base(filename)
+	// Extract number from stageN.txt format
+	stageNum := 1
+	if strings.HasPrefix(baseName, "stage") && strings.HasSuffix(baseName, ".txt") {
+		numStr := strings.TrimPrefix(strings.TrimSuffix(baseName, ".txt"), "stage")
+		if num, err := strconv.Atoi(numStr); err == nil {
+			stageNum = num
+		}
+	}
+
+	stageData := &StageData{StageNumber: stageNum}
+
+	// Create a 2D grid to track processed cells
+	height := len(lines)
+	width := 0
+	for _, line := range lines {
+		if len(line) > width {
+			width = len(line)
+		}
+	}
+
+	processed := make([][]bool, height)
+	for i := range processed {
+		processed[i] = make([]bool, width)
+	}
+
+	// Parse the grid
+	for y, line := range lines {
+		for x, char := range line {
+			if processed[y][x] {
+				continue
+			}
+
+			switch char {
+			case 'O':
+				// Find rectangular platform starting from this position
+				platform := findRectangularPlatform(lines, processed, x, y, 'O')
+				if platform != nil {
+					stageData.Platforms = append(stageData.Platforms, *platform)
+				}
+			case 'G':
+				// Find rectangular goal platform starting from this position
+				platform := findRectangularPlatform(lines, processed, x, y, 'G')
+				if platform != nil {
+					stageData.GoalPlatforms = append(stageData.GoalPlatforms, *platform)
+				}
+			case 'L':
+				stageData.BlueStartX = x
+				stageData.BlueStartY = y
+				stageData.BlueStartPixelX = x * 20
+				stageData.BlueStartPixelY = y * 20
+				processed[y][x] = true
+			case 'R':
+				stageData.RedStartX = x
+				stageData.RedStartY = y
+				stageData.RedStartPixelX = x * 20
+				stageData.RedStartPixelY = y * 20
+				processed[y][x] = true
+			case '.':
+				processed[y][x] = true
+			}
+		}
+	}
+
+	return stageData, nil
+}
+
+// findRectangularPlatform finds a rectangular platform starting from (startX, startY)
+func findRectangularPlatform(lines []string, processed [][]bool, startX, startY int, targetChar rune) *PlatformData {
+	if startY >= len(lines) || startX >= len(lines[startY]) {
+		return nil
+	}
+
+	if rune(lines[startY][startX]) != targetChar {
+		return nil
+	}
+
+	// Find the width by scanning right
+	width := 0
+	for x := startX; x < len(lines[startY]) && rune(lines[startY][x]) == targetChar; x++ {
+		width++
+	}
+
+	// Find the height by scanning down, ensuring all rows have the same width
+	height := 0
+	for y := startY; y < len(lines); y++ {
+		// Check if this row has the required width of target characters
+		if len(lines[y]) < startX+width {
+			break
+		}
+		hasFullWidth := true
+		for x := startX; x < startX+width; x++ {
+			if rune(lines[y][x]) != targetChar {
+				hasFullWidth = false
+				break
+			}
+		}
+		if !hasFullWidth {
+			break
+		}
+		height++
+	}
+
+	// Mark all cells in this rectangle as processed
+	for y := startY; y < startY+height; y++ {
+		for x := startX; x < startX+width; x++ {
+			if y < len(processed) && x < len(processed[y]) {
+				processed[y][x] = true
+			}
+		}
+	}
+
+	return &PlatformData{
+		X:      startX,
+		Y:      startY,
+		Width:  width,
+		Height: height,
+	}
+}
+
+// generateStageFile generates a Go stage file from stage data
+func generateStageFile(stageData *StageData, outputPath string) error {
+	tmpl := `package main
+
+// LoadStage{{.StageNumber}} creates stage {{.StageNumber}} - Generated from ASCII art
+// Grid layout: 40x30 cells (800x600 pixels with 20px cells)
+func LoadStage{{.StageNumber}}() *Stage {
+	return &Stage{
+		Platforms: []Platform{
+			// Ground platform (full width, 3 cells high at bottom)
+			CreateGridGroundPlatform(),
+{{range .Platforms}}
+			// Regular platform at ({{.X}}, {{.Y}}) size {{.Width}}x{{.Height}}
+			CreateGridPlatform({{.X}}, {{.Y}}, {{.Width}}, {{.Height}}),
+{{end}}{{range .GoalPlatforms}}
+			// Goal platform at ({{.X}}, {{.Y}}) size {{.Width}}x{{.Height}}
+			CreateGridGoalPlatform({{.X}}, {{.Y}}, {{.Width}}, {{.Height}}),
+{{end}}
+		},
+	}
+}
+
+// GetStage{{.StageNumber}}StartPositions returns the starting positions for stage {{.StageNumber}}
+func GetStage{{.StageNumber}}StartPositions() (blueX, blueY, redX, redY float64) {
+	// Convert grid coordinates to pixel coordinates
+	return {{.BlueStartPixelX}}, {{.BlueStartPixelY}}, {{.RedStartPixelX}}, {{.RedStartPixelY}}
+}
+`
+
+	t, err := template.New("stage").Parse(tmpl)
+	if err != nil {
+		return fmt.Errorf("テンプレート解析エラー: %v", err)
+	}
+
+	file, err := os.Create(outputPath)
+	if err != nil {
+		return fmt.Errorf("出力ファイル作成エラー: %v", err)
+	}
+	defer file.Close()
+
+	if err := t.Execute(file, stageData); err != nil {
+		return fmt.Errorf("テンプレート実行エラー: %v", err)
+	}
+
+	return nil
+}
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintf(os.Stderr, "使用方法: %s <input.txt>\n", os.Args[0])
+		fmt.Fprintf(os.Stderr, "例: %s stage1.txt\n", os.Args[0])
+		os.Exit(1)
+	}
+
+	inputFile := os.Args[1]
+
+	// Parse ASCII art
+	stageData, err := parseASCIIArt(inputFile)
+	if err != nil {
+		log.Fatalf("ASCII art解析エラー: %v", err)
+	}
+
+	// Generate output filename
+	baseName := filepath.Base(inputFile)
+	outputName := strings.TrimSuffix(baseName, ".txt") + ".go"
+
+	// Generate stage file
+	if err := generateStageFile(stageData, outputName); err != nil {
+		log.Fatalf("ステージファイル生成エラー: %v", err)
+	}
+
+	fmt.Printf("ステージファイルを生成しました: %s\n", outputName)
+	fmt.Printf("ステージ番号: %d\n", stageData.StageNumber)
+	fmt.Printf("プラットフォーム数: %d\n", len(stageData.Platforms))
+	fmt.Printf("ゴールプラットフォーム数: %d\n", len(stageData.GoalPlatforms))
+	fmt.Printf("青キャラ開始位置: (%d, %d)\n", stageData.BlueStartX, stageData.BlueStartY)
+	fmt.Printf("赤キャラ開始位置: (%d, %d)\n", stageData.RedStartX, stageData.RedStartY)
+}

--- a/cmd/stagegen/main.go
+++ b/cmd/stagegen/main.go
@@ -64,6 +64,8 @@ func parseASCIIArt(filename string) (*StageData, error) {
 		numStr := strings.TrimPrefix(strings.TrimSuffix(baseName, ".txt"), "stage")
 		if num, err := strconv.Atoi(numStr); err == nil {
 			stageNum = num
+		} else if numStr != "" {
+			log.Printf("警告: ファイル名 '%s' からステージ番号を抽出できませんでした。デフォルトの1を使用します。", baseName)
 		}
 	}
 
@@ -117,6 +119,8 @@ func parseASCIIArt(filename string) (*StageData, error) {
 				processed[y][x] = true
 			case '.':
 				processed[y][x] = true
+			default:
+				return nil, fmt.Errorf("不明な文字 '%c' が座標 (%d, %d) で見つかりました", char, x, y)
 			}
 		}
 	}


### PR DESCRIPTION
Closes #17

## 概要
ASCII artからステージを生成するツールを作成しました。

## 機能
- ASCII art (.txt) からステージファイル (.go) を生成
- 矩形プラットフォームの自動検出
- キャラクター開始位置の設定
- グリッド座標系（40x30セル）対応

## 使用方法
```bash
go run cmd/stagegen/main.go stage1.txt
```

Generated with [Claude Code](https://claude.ai/code)